### PR TITLE
Add wrist calibration tracking and motor overload auto-recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# Claude Code Instructions
+
+## Project: ORCA Core
+
+Control package for the ORCA Hand - a dexterous open-source robotic hand. Provides hardware abstraction, calibration tools, and high-level joint-space control.
+
+## Project Structure
+
+```
+orca_core/
+├── api/              # High-level control API
+├── hardware/         # Hardware interfaces (motors)
+│   ├── dynamixel_client.py      # Dynamixel motor control
+├── utils/            # Shared utilities
+├── configs/          # Hand configurations (YAML)
+└── core.py           # Main OrcaHand API
+
+scripts/              # CLI tools for calibration, demos
+tests/                # Unit tests
+docs/                 # Documentation
+```
+
+### Key Files
+
+- [orca_core/core.py](orca_core/core.py) - Main `OrcaHand` class API
+- [orca_core/hardware/dynamixel_client.py](orca_core/hardware/dynamixel_client.py) - Motor control interface
+- [orca_core/configs/*/config.yaml](orca_core/configs/) - Hand configuration files
+- [scripts/](scripts/) - Calibration and utility scripts
+
+### Hardware Components
+
+| Component | Interface | Description |
+|-----------|-----------|-------------|
+| Dynamixel Motors | `dynamixel_client.py` | Servo motor control (17 motors) |
+| Hand Configuration | `config.yaml` | Joint mapping, ROMs, calibration |
+
+---
+
+## Workflow
+
+### Git & PRs
+
+- Work on feature branches: `feature/description` or `fix/description`
+- Never push directly to `main`
+- Create PRs for all changes
+
+### Commit Guidelines
+
+- Use conventional commits: `Add feature`, `Fix bug`, `Update docs`
+- Keep messages concise and descriptive
+- Do NOT add `Co-Authored-By` lines
+
+---
+
+## Code Style
+
+**Keep code clean and readable:**
+
+- Write concise, self-documenting code
+- Avoid excessive comments - prefer clear variable/function names
+- Only add comments for complex logic or non-obvious design decisions
+- Remove commented-out code before committing
+- Follow existing patterns in the codebase
+
+---
+
+## Development
+
+### Virtual Environment
+
+**IMPORTANT:** Always activate the virtual environment before running any Python commands or installing packages:
+
+```bash
+source venv/bin/activate
+```
+
+Never install packages to the base/system Python environment. All dependencies should be installed within the venv.
+
+### Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -e .
+```
+
+### Testing
+
+```bash
+source venv/bin/activate
+pytest tests/
+```
+
+### Common Scripts
+
+```bash
+# Calibration workflow
+python scripts/tension.py orca_core/configs/orcahand_v1_right
+python scripts/calibrate.py orca_core/configs/orcahand_v1_right
+python scripts/neutral.py orca_core/configs/orcahand_v1_right
+
+# Manual control
+python scripts/slider_joint.py orca_core/configs/orcahand_v1_right
+python scripts/slider_motor.py orca_core/configs/orcahand_v1_right
+```
+
+### Configuration
+
+All hand-specific settings are in `config.yaml`:
+- Motor-to-joint mapping
+- Joint ROMs (ranges of motion)
+- Neutral positions
+- Calibration sequences
+
+---
+
+## Technical Notes
+
+### Control Modes
+
+- `current_based_position` (recommended) - Position control with current feedback
+- `position` - Direct position control
+- `current` - Direct current control
+- `velocity` - Velocity control
+
+### Joint Naming Convention
+
+Format: `{finger}_{joint_type}`
+
+Fingers: `thumb`, `index`, `middle`, `ring`, `pinky`, `wrist`
+Joint types: `mcp`, `pip`, `dip`, `abd` (abduction)
+
+Example: `index_mcp`, `thumb_pip`
+
+---
+
+## Architecture
+
+See [docs/architecture-diagram.md](docs/architecture-diagram.md) for visual diagrams of:
+- System overview and component interactions
+- Data flow and sequence diagrams
+- Directory structure
+- Calibration workflow

--- a/scripts/calibrate.py
+++ b/scripts/calibrate.py
@@ -12,6 +12,11 @@ def main():
         default=None,
         help="Path to the orcahand model folder (e.g., /path/to/orcahand_v1)"
     )
+    parser.add_argument(
+        "--force-wrist",
+        action="store_true",
+        help="Force wrist calibration even if already calibrated"
+    )
     args = parser.parse_args()
 
     hand = OrcaHand(args.model_path)
@@ -22,7 +27,7 @@ def main():
         print("Failed to connect to the hand.")
         exit(1)
 
-    hand.calibrate()
+    hand.calibrate(force_wrist=args.force_wrist)
 
 if __name__ == "__main__":
     main()

--- a/scripts/debug_overload.py
+++ b/scripts/debug_overload.py
@@ -1,0 +1,65 @@
+"""Debug script to test overload detection and reboot step by step."""
+
+import argparse
+import logging
+import time
+from orca_core.hardware.dynamixel_client import DynamixelClient
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=str, default="/dev/tty.usbserial-FTAK89H0")
+    parser.add_argument("--baudrate", type=int, default=3000000)
+    parser.add_argument("--motor_id", type=int, default=2)
+    args = parser.parse_args()
+
+    mid = args.motor_id
+    dxl_client = DynamixelClient([mid], args.port, args.baudrate)
+
+    # Open port manually — don't call connect() which retries torque enable forever
+    dxl_client.port_handler.openPort()
+    dxl_client.port_handler.setBaudRate(dxl_client.baudrate)
+    print("Port opened.")
+
+    print(f"\n=== Step 1: Read hardware error status ===")
+    hw_err = dxl_client.read_hardware_error(mid)
+    print(f"Hardware error: 0x{hw_err:02X} (overload={'YES' if hw_err & 0x20 else 'no'})")
+
+    if not (hw_err & 0x20):
+        print("No overload detected. Run test_overload.py first to trigger one.")
+        dxl_client.port_handler.closePort()
+        return
+
+    print(f"\n=== Step 2: Reboot motor {mid} ===")
+    dxl_client.reboot_motor(mid)
+    print("Reboot command sent.")
+
+    for wait_total in [0.3, 0.6, 1.0, 2.0]:
+        time.sleep(0.3 if wait_total == 0.3 else wait_total - 0.3)
+        hw_err = dxl_client.read_hardware_error(mid)
+        print(f"  After {wait_total:.1f}s: hw_err=0x{hw_err:02X} ({'STILL ERROR' if hw_err else 'CLEARED'})")
+        if not hw_err:
+            break
+
+    if hw_err:
+        print("\nHardware error did NOT clear after reboot.")
+        dxl_client.port_handler.closePort()
+        return
+
+    print(f"\n=== Step 3: Set operating mode 5 + enable torque ===")
+    dxl_client.set_torque_enabled([mid], False, retries=0)
+    dxl_client.set_operating_mode([mid], 5)
+    print("Operating mode set, torque enabled.")
+
+    print(f"\n=== Step 4: Read position ===")
+    pos, vel, cur = dxl_client.read_pos_vel_cur()
+    print(f"pos={pos[0]:.3f}  vel={vel[0]:.3f}  cur={cur[0]:.1f}")
+
+    print("\nReboot and recovery successful!")
+    dxl_client.port_handler.closePort()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,158 @@
+"""ORCA Hand full setup script.
+
+Runs the complete tension → calibrate → test → verify workflow.
+Three rounds of tension+calibration with a 1-minute motion test in between.
+"""
+
+import argparse
+import sys
+import time
+from orca_core import OrcaHand
+
+
+DIVIDER = "=" * 60
+
+
+def wait_for_enter(msg="Press ENTER to continue..."):
+    input(f"\n>>> {msg}")
+
+
+def print_step(step_num, title):
+    print(f"\n{DIVIDER}")
+    print(f"  STEP {step_num}: {title}")
+    print(DIVIDER)
+
+
+def run_tension(hand, step_num, label):
+    """Run tension with move_motors in background, wait for user to press Enter."""
+    print_step(step_num, f"TENSION — {label}")
+    print("  Motors will move to set initial tension, then hold.")
+    print("  Adjust tendons while motors are holding.")
+    hand.tension(move_motors=True, blocking=False)
+    wait_for_enter("Press ENTER when tensioning is done...")
+    hand.stop_task()
+    print("  Tension complete.")
+
+
+def run_calibrate(hand, step_num, label, force_wrist=False):
+    """Run calibration."""
+    print_step(step_num, f"CALIBRATE — {label}")
+    if force_wrist:
+        print("  Calibrating all joints including wrist...")
+    else:
+        print("  Calibrating finger joints (wrist already calibrated, skipping)...")
+    hand.calibrate(force_wrist=force_wrist)
+    print("  Calibration complete.")
+
+
+def run_neutral(hand, step_num):
+    """Move to neutral position."""
+    print_step(step_num, "NEUTRAL POSITION")
+    print("  Moving hand to neutral position...")
+    hand.enable_torque()
+    hand.set_control_mode('current_based_position')
+    hand.set_neutral_position()
+    print("  Hand is in neutral position.")
+
+
+def run_motion_test(hand, step_num, duration=60):
+    """Open/close the hand repeatedly for `duration` seconds with countdown."""
+    print_step(step_num, f"MOTION TEST — {duration}s")
+    print("  Opening and closing the hand to verify calibration.")
+    print("  Watch for any issues with finger movement.\n")
+
+    hand.enable_torque()
+    hand.set_control_mode('current_based_position')
+
+    open_pos = {
+        "index_pip": -10, "middle_pip": -10, "ring_pip": -10, "pinky_pip": -10,
+        "thumb_dip": -30,
+        "thumb_mcp": -40, "index_mcp": -40, "middle_mcp": -40, "ring_mcp": -40, "pinky_mcp": -40,
+        "thumb_abd": 0, "index_abd": 0, "middle_abd": 0, "ring_abd": 0, "pinky_abd": 0,
+    }
+    closed_pos = {
+        "thumb_mcp": 45, "index_mcp": 45, "middle_mcp": 45, "ring_mcp": 45, "pinky_mcp": 45,
+        "thumb_dip": 90, "index_pip": 90, "middle_pip": 90, "ring_pip": 90, "pinky_pip": 90,
+        "thumb_abd": 40,
+    }
+
+    start = time.time()
+    cycle = 0
+    while True:
+        remaining = duration - (time.time() - start)
+        if remaining <= 0:
+            break
+
+        if cycle % 2 == 0:
+            print(f"  [{int(remaining):3d}s left]  OPEN")
+            hand.set_joint_pos(open_pos, num_steps=25, step_size=0.001)
+        else:
+            print(f"  [{int(remaining):3d}s left]  CLOSE")
+            hand.set_joint_pos(closed_pos, num_steps=25, step_size=0.001)
+        cycle += 1
+
+        hold_end = min(time.time() + 2.0, start + duration)
+        while time.time() < hold_end:
+            time.sleep(0.1)
+
+    hand.set_neutral_position()
+    print("  Motion test complete.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Full ORCA Hand setup workflow.")
+    parser.add_argument(
+        "model_path", type=str, nargs="?", default=None,
+        help="Path to the hand model directory"
+    )
+    args = parser.parse_args()
+
+    print(DIVIDER)
+    print("  ORCA HAND SETUP")
+    print("  Full calibration and verification workflow")
+    print(DIVIDER)
+
+    hand = OrcaHand(args.model_path)
+    success, message = hand.connect()
+    if not success:
+        print(f"Failed to connect: {message}")
+        sys.exit(1)
+    print(f"  Connected: {message}")
+
+    try:
+        # --- Round 1: Initial tension + calibration (with wrist) ---
+        run_tension(hand, 1, "Initial tensioning")
+
+        wait_for_enter("Place the hand in a neutral position, then press ENTER...")
+
+        run_calibrate(hand, 2, "First calibration (with wrist)", force_wrist=True)
+
+        # --- Round 2: Re-tension + calibration (without wrist) ---
+        run_tension(hand, 3, "Second tensioning")
+
+        run_neutral(hand, 4)
+
+        run_calibrate(hand, 5, "Second calibration (fingers only)")
+
+        # --- Motion test ---
+        run_motion_test(hand, 6, duration=60)
+
+        # --- Round 3: Final tension + calibration ---
+        run_tension(hand, 7, "Final tensioning")
+
+        run_calibrate(hand, 8, "Final calibration (fingers only)")
+
+        run_neutral(hand, 9)
+
+        print(f"\n{DIVIDER}")
+        print("  Done. Have fun playing with ORCA!")
+        print(DIVIDER)
+
+    except KeyboardInterrupt:
+        print("\n\n  Setup interrupted by user.")
+    finally:
+        hand.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -27,7 +27,8 @@ def run_tension(hand, step_num, label):
     """Run tension with move_motors in background, wait for user to press Enter."""
     print_step(step_num, f"TENSION — {label}")
     print("  Motors will move to set initial tension, then hold.")
-    print("  Adjust tendons while motors are holding.")
+    print("  Use the tensioning tool or pliers to turn the top spool clockwise.")
+    print("  Do NOT overtension — just enough to remove slack.")
     hand.tension(move_motors=True, blocking=False)
     wait_for_enter("Press ENTER when tensioning is done...")
     hand.stop_task()

--- a/scripts/test_overload.py
+++ b/scripts/test_overload.py
@@ -1,0 +1,45 @@
+"""Test overload detection and auto-recovery.
+
+Connect a single motor, slowly increment position, and physically block
+the finger to trigger an overload. Recovery happens automatically via
+the bulk read path in DynamixelClient.
+"""
+
+import argparse
+import logging
+import time
+from orca_core.hardware.dynamixel_client import DynamixelClient
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test overload detection and auto-recovery.")
+    parser.add_argument("--port", type=str, default="/dev/tty.usbserial-FT9MISJT")
+    parser.add_argument("--baudrate", type=int, default=3000000)
+    parser.add_argument("--motor_id", type=int, default=2)
+    args = parser.parse_args()
+
+    mid = args.motor_id
+    dxl_client = DynamixelClient([mid], args.port, args.baudrate)
+    dxl_client.connect()
+    dxl_client.set_operating_mode([mid], 5)  # current-based position
+
+    print(f"Motor {mid} ready. Block the finger to trigger overload.")
+    try:
+        while True:
+            hw_err = dxl_client.read_hardware_error(mid)
+            pos, vel, cur = dxl_client.read_pos_vel_cur()
+            target = pos + 0.3
+            dxl_client.write_desired_pos([mid], target)
+            err_str = f"  HW_ERR=0x{hw_err:02X}" if hw_err else ""
+            print(f"pos={pos[0]:.3f}  target={target[0]:.3f}  cur={cur[0]:.1f}{err_str}")
+            time.sleep(0.05)
+    except KeyboardInterrupt:
+        print("\nStopping.")
+    finally:
+        dxl_client.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Wrist calibration tracking**: Avoids redundant recalibration by tracking whether wrist motors have already been calibrated during a session
- **Overload detection & auto-recovery**: When a Dynamixel motor hits an overload (e.g. finger blocked by an object), automatically detects the hardware error, reboots the motor, restores its operating mode, and re-enables torque within ~0.3s

## Changes

- `orca_core/hardware/dynamixel_client.py` — Added `reboot_motor()`, `read_hardware_error()`, `check_overload_and_reboot()` methods; periodic hardware error checks in bulk read path; pre-existing error clearing in `connect()`
- `scripts/test_overload.py` — Test script to trigger and observe overload recovery
- `scripts/debug_overload.py` — Step-by-step debug script for the reboot flow

## Test plan

- [ ] Run `scripts/test_overload.py`, physically block a finger to trigger overload, observe auto-recovery
- [ ] Verify normal operation is unaffected (no extra latency in control loop)
- [ ] Run `pytest tests/` to confirm no regressions