### PR TITLE
Refactor test suite from unittest to pytest

### DIFF
--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,8 +1,7 @@
-import unittest
-import tempfile
 import os
 import shutil
-import yaml
+
+import pytest
 from orca_core import MockOrcaHand
 from orca_core.utils import read_yaml
 
@@ -13,54 +12,45 @@ REAL_CALIB = os.path.join(MODEL_DIR, "calibration.yaml")
 
 EXPECTED_LIMITS = [-1.0, 1.0]
 
-class TestOrcaHandCalibration(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        self.config_path = os.path.join(self.temp_dir, "config.yaml")
-        self.calib_path = os.path.join(self.temp_dir, "calibration.yaml")
-        shutil.copy(REAL_CONFIG, self.config_path)
-        shutil.copy(REAL_CALIB, self.calib_path)
 
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir)
-        
-    def check_calibrated(self, hand):
-        self.assertTrue(hand.calibrated, "Hand should be marked as calibrated")
-
-        calib = read_yaml(self.calib_path)
-        
-        motor_limits_file = calib.get('motor_limits', {})
-        motor_limits = hand.motor_limits_dict
-        if motor_limits != motor_limits_file:
-            print(f"motor_limits from hand: {motor_limits}")
-            print(f"motor_limits from file: {motor_limits_file}")
-        self.assertEqual(motor_limits, motor_limits_file, "Motor limits do not match between hand and calibration file")
-        
-        joint_to_motor_ratios_file = calib.get('joint_to_motor_ratios', {})
-        joint_to_motor_ratios = hand.joint_to_motor_ratios_dict
-        if joint_to_motor_ratios != joint_to_motor_ratios_file:
-            print(f"joint_to_motor_ratios from hand: {joint_to_motor_ratios}")
-            print(f"joint_to_motor_ratios from file: {joint_to_motor_ratios_file}")
-        self.assertEqual(joint_to_motor_ratios, joint_to_motor_ratios_file, "Joint to motor ratios do not match between hand and calibration file")
-        
-        for mid, ratio in joint_to_motor_ratios.items():
-            self.assertNotEqual(ratio, 0, f"Joint to motor ratio for motor {mid} should not be 0")
-            self.assertGreaterEqual(motor_limits[mid][0], EXPECTED_LIMITS[0], f"Motor {mid} min limit is below expected")
-            self.assertLessEqual(motor_limits[mid][1], EXPECTED_LIMITS[1], f"Motor {mid} max limit is above expected")
+@pytest.fixture
+def calib_dir(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    calib_path = tmp_path / "calibration.yaml"
+    shutil.copy(REAL_CONFIG, config_path)
+    shutil.copy(REAL_CALIB, calib_path)
+    return tmp_path
 
 
-    def test_calibration_yaml_missing(self):
-        os.remove(self.calib_path)
-        hand = MockOrcaHand(self.temp_dir)
-        hand.connect()
-    
-        self.assertFalse(hand.calibrated, "Hand should not be marked as calibrated before calibration")
-        
-        hand.calibrate()
+def check_calibrated(hand, calib_path):
+    assert hand.calibrated, "Hand should be marked as calibrated"
 
-        self.assertTrue(os.path.exists(self.calib_path), "calibration.yaml should be created")
-        
-        self.check_calibrated(hand)
+    calib = read_yaml(str(calib_path))
 
-if __name__ == "__main__":
-    unittest.main()
+    motor_limits_file = calib.get('motor_limits', {})
+    motor_limits = hand.motor_limits_dict
+    assert motor_limits == motor_limits_file, "Motor limits do not match between hand and calibration file"
+
+    joint_to_motor_ratios_file = calib.get('joint_to_motor_ratios', {})
+    joint_to_motor_ratios = hand.joint_to_motor_ratios_dict
+    assert joint_to_motor_ratios == joint_to_motor_ratios_file, "Joint to motor ratios do not match between hand and calibration file"
+
+    for mid, ratio in joint_to_motor_ratios.items():
+        assert ratio != 0, f"Joint to motor ratio for motor {mid} should not be 0"
+        assert motor_limits[mid][0] >= EXPECTED_LIMITS[0], f"Motor {mid} min limit is below expected"
+        assert motor_limits[mid][1] <= EXPECTED_LIMITS[1], f"Motor {mid} max limit is above expected"
+
+
+def test_calibration_yaml_missing(calib_dir):
+    calib_path = calib_dir / "calibration.yaml"
+    os.remove(calib_path)
+    hand = MockOrcaHand(str(calib_dir))
+    hand.connect()
+
+    assert not hand.calibrated, "Hand should not be marked as calibrated before calibration"
+
+    hand.calibrate()
+
+    assert calib_path.exists(), "calibration.yaml should be created"
+
+    check_calibrated(hand, calib_path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,43 +1,28 @@
-import unittest
-
 from orca_core import MockOrcaHand, OrcaHand
 
-class TestOrcaCore(unittest.TestCase):
-    def test_import_and_instantiation(self):
-        try:
-            hand = OrcaHand()
-            self.assertIsInstance(hand, OrcaHand)
-        except ImportError as e:
-            self.fail(f"ImportError: {e}")
-        except Exception as e:
-            self.fail(f"Failed to instantiate OrcaHand: {e}")
 
-    def test_orca_hand_exposes_hardware_methods(self):
-        hand = OrcaHand()
-        for method_name in [
-            "connect",
-            "disconnect",
-            "enable_torque",
-            "disable_torque",
-            "set_control_mode",
-            "set_max_current",
-            "calibrate",
-            "tension",
-            "jitter",
-        ]:
-            self.assertTrue(hasattr(hand, method_name), f"Missing hardware method: {method_name}")
+def test_import_and_instantiation():
+    hand = OrcaHand()
+    assert isinstance(hand, OrcaHand)
 
-    def test_mock_connection(self):
-        try:
-            mock_hand = MockOrcaHand()
-            status = mock_hand.connect()
-            self.assertTrue(status[0], "Mock connection failed")
-        except ImportError as e:
-            self.fail(f"ImportError: {e}")
-        except Exception as e:
-            self.fail(f"Failed to connect MockOrcaHand: {e}")
 
-if __name__ == "__main__":
-    unittest.main()
-    
-    
+def test_orca_hand_exposes_hardware_methods():
+    hand = OrcaHand()
+    for method_name in [
+        "connect",
+        "disconnect",
+        "enable_torque",
+        "disable_torque",
+        "set_control_mode",
+        "set_max_current",
+        "calibrate",
+        "tension",
+        "jitter",
+    ]:
+        assert hasattr(hand, method_name), f"Missing hardware method: {method_name}"
+
+
+def test_mock_connection():
+    mock_hand = MockOrcaHand()
+    status = mock_hand.connect()
+    assert status[0], "Mock connection failed"

--- a/tests/test_hardware_hand.py
+++ b/tests/test_hardware_hand.py
@@ -1,12 +1,9 @@
 import os
 import shutil
-import tempfile
-import unittest
 
 import numpy as np
-
+import pytest
 from orca_core import MockOrcaHand
-
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_DIR = os.path.join(REPO_ROOT, "orca_core", "models", "orcahand_v1_right")
@@ -14,76 +11,74 @@ REAL_CONFIG = os.path.join(MODEL_DIR, "config.yaml")
 REAL_CALIB = os.path.join(MODEL_DIR, "calibration.yaml")
 
 
-class TestHardwareHand(unittest.TestCase):
-    def setUp(self):
-        self.hand = MockOrcaHand()
-        success, msg = self.hand.connect()
-        self.assertTrue(success, f"Failed to connect mock hand: {msg}")
-
-    def tearDown(self):
-        self.hand.stop_task()
-        self.hand.disconnect()
-
-    def test_connect_disconnect_updates_connection_state(self):
-        self.assertTrue(self.hand.is_connected())
-        success, _ = self.hand.disconnect()
-        self.assertTrue(success)
-        self.assertFalse(self.hand.is_connected())
-
-    def test_set_control_mode_preserves_wrist_special_case(self):
-        wrist_motor_id = self.hand.joint_to_motor_map.get("wrist")
-        self.hand.set_control_mode("current_based_position")
-
-        for motor_id in self.hand.motor_ids:
-            expected_mode = 4 if motor_id == wrist_motor_id else 5
-            self.assertEqual(self.hand._motor_client._operating_mode[motor_id], expected_mode)
-
-    def test_set_max_current_supports_scalar_and_list(self):
-        self.hand.set_max_current(123.0)
-        self.assertTrue(all(current == 123.0 for current in self.hand._motor_client._cur.values()))
-
-        desired_currents = [float(idx) for idx in range(len(self.hand.motor_ids))]
-        self.hand.set_max_current(desired_currents)
-        for motor_id, desired in zip(self.hand.motor_ids, desired_currents):
-            self.assertEqual(self.hand._motor_client._cur[motor_id], desired)
-
-    def test_disconnect_disables_torque(self):
-        self.hand.disconnect()
-        self.assertTrue(all(not enabled for enabled in self.hand._motor_client._torque_enabled.values()))
+@pytest.fixture
+def mock_hand():
+    hand = MockOrcaHand()
+    success, msg = hand.connect()
+    assert success, f"Failed to connect: {msg}"
+    yield hand
+    hand.stop_task()
+    hand.disconnect()
 
 
-class TestHardwareHandRoundTrip(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        shutil.copy(REAL_CONFIG, os.path.join(self.temp_dir, "config.yaml"))
-        shutil.copy(REAL_CALIB, os.path.join(self.temp_dir, "calibration.yaml"))
-        self.hand = MockOrcaHand(self.temp_dir)
-        success, msg = self.hand.connect()
-        self.assertTrue(success, f"Failed to connect mock hand: {msg}")
-        self.hand.calibrate()
+@pytest.fixture
+def calibrated_hand(tmp_path):
+    shutil.copy(REAL_CONFIG, tmp_path / "config.yaml")
+    shutil.copy(REAL_CALIB, tmp_path / "calibration.yaml")
+    hand = MockOrcaHand(str(tmp_path))
+    success, msg = hand.connect()
+    assert success, f"Failed to connect: {msg}"
+    hand.calibrate()
+    yield hand
+    hand.stop_task()
+    hand.disconnect()
 
-    def tearDown(self):
-        self.hand.stop_task()
-        self.hand.disconnect()
-        shutil.rmtree(self.temp_dir)
 
-    def test_calibrated_joint_command_round_trips_through_motor_mapping(self):
-        target = {}
-        for joint in self.hand.joint_ids[:3]:
-            min_pos, max_pos = self.hand.joint_roms_dict[joint]
-            target[joint] = (min_pos + max_pos) / 2.0
+def test_connect_disconnect_updates_connection_state(mock_hand):
+    assert mock_hand.is_connected()
+    success, _ = mock_hand.disconnect()
+    assert success
+    assert not mock_hand.is_connected()
 
-        self.hand.set_joint_pos(target)
-        actual = self.hand.get_joint_pos(as_list=False)
-        for joint, expected in target.items():
-            self.assertAlmostEqual(actual[joint], expected, places=5)
 
-    def test_calibrated_list_command_round_trips(self):
-        command = []
-        for joint in self.hand.joint_ids:
-            min_pos, max_pos = self.hand.joint_roms_dict[joint]
-            command.append((min_pos + max_pos) / 4.0)
+def test_set_control_mode_preserves_wrist_special_case(mock_hand):
+    wrist_motor_id = mock_hand.joint_to_motor_map.get("wrist")
+    mock_hand.set_control_mode("current_based_position")
+    for motor_id in mock_hand.motor_ids:
+        expected_mode = 4 if motor_id == wrist_motor_id else 5
+        assert mock_hand._motor_client._operating_mode[motor_id] == expected_mode
 
-        self.hand.set_joint_pos(command)
-        actual = np.array(self.hand.get_joint_pos(as_list=True))
-        np.testing.assert_allclose(actual, np.array(command), atol=1e-6)
+
+def test_set_max_current_supports_scalar_and_list(mock_hand):
+    mock_hand.set_max_current(123.0)
+    assert all(current == 123.0 for current in mock_hand._motor_client._cur.values())
+    desired_currents = [float(idx) for idx in range(len(mock_hand.motor_ids))]
+    mock_hand.set_max_current(desired_currents)
+    for motor_id, desired in zip(mock_hand.motor_ids, desired_currents):
+        assert mock_hand._motor_client._cur[motor_id] == desired
+
+
+def test_disconnect_disables_torque(mock_hand):
+    mock_hand.disconnect()
+    assert all(not enabled for enabled in mock_hand._motor_client._torque_enabled.values())
+
+
+def test_calibrated_joint_command_round_trips_through_motor_mapping(calibrated_hand):
+    target = {}
+    for joint in calibrated_hand.joint_ids[:3]:
+        min_pos, max_pos = calibrated_hand.joint_roms_dict[joint]
+        target[joint] = (min_pos + max_pos) / 2.0
+    calibrated_hand.set_joint_pos(target)
+    actual = calibrated_hand.get_joint_pos(as_list=False)
+    for joint, expected in target.items():
+        assert actual[joint] == pytest.approx(expected, abs=1e-5)
+
+
+def test_calibrated_list_command_round_trips(calibrated_hand):
+    command = []
+    for joint in calibrated_hand.joint_ids:
+        min_pos, max_pos = calibrated_hand.joint_roms_dict[joint]
+        command.append((min_pos + max_pos) / 4.0)
+    calibrated_hand.set_joint_pos(command)
+    actual = np.array(calibrated_hand.get_joint_pos(as_list=True))
+    np.testing.assert_allclose(actual, np.array(command), atol=1e-6)

--- a/tests/test_jitter.py
+++ b/tests/test_jitter.py
@@ -1,143 +1,137 @@
-import unittest
 import time
 import inspect
+
 import numpy as np
+import pytest
 from unittest.mock import patch
 from orca_core import MockOrcaHand
 
 
-class TestOrcaHandJitter(unittest.TestCase):
-
-    def setUp(self):
-        self.hand = MockOrcaHand()
-        success, msg = self.hand.connect()
-        self.assertTrue(success, f"Failed to connect mock hand: {msg}")
-        self.wrist_motor_id = self.hand.joint_to_motor_map.get("wrist")
-
-    def tearDown(self):
-        self.hand.stop_task()
-        time.sleep(0.1)
-        self.hand.disconnect()
-
-    # ── Amplitude safety ──
-
-    def test_amplitude_exceeds_max_raises_error(self):
-        with self.assertRaises(ValueError):
-            self.hand.jitter(amplitude=15.0, duration=0.1)
-
-    def test_amplitude_at_max_allowed(self):
-        self.hand.jitter(amplitude=10.0, duration=0.1)
-
-    def test_amplitude_below_max(self):
-        self.hand.jitter(amplitude=3.0, duration=0.1)
-
-    # ── Default frequency ──
-
-    def test_default_frequency_is_fast(self):
-        sig = inspect.signature(self.hand.jitter)
-        default_freq = sig.parameters['frequency'].default
-        self.assertGreaterEqual(default_freq, 10.0)
-
-    # ── Duration ──
-
-    def test_duration_respected(self):
-        start = time.time()
-        self.hand.jitter(duration=1.0, amplitude=2.0)
-        elapsed = time.time() - start
-        self.assertAlmostEqual(elapsed, 1.0, delta=0.3)
-
-    def test_short_duration(self):
-        start = time.time()
-        self.hand.jitter(duration=0.3, amplitude=2.0)
-        elapsed = time.time() - start
-        self.assertLess(elapsed, 1.0)
-
-    # ── Motor selection ──
-
-    def test_custom_motor_ids(self):
-        target_id = self.hand.motor_ids[0]
-        with patch.object(self.hand._motor_client, 'write_desired_pos', wraps=self.hand._motor_client.write_desired_pos) as mock_write:
-            self.hand.jitter(motor_ids=[target_id], amplitude=5.0, duration=0.2)
-            self.assertGreater(len(mock_write.call_args_list), 0)
-            for call_args in mock_write.call_args_list:
-                self.assertEqual(call_args[0][0], [target_id])
-
-    # ── Default excludes wrist ──
-
-    def test_default_excludes_wrist(self):
-        self.assertIsNotNone(self.wrist_motor_id, "Config must have a wrist motor for this test")
-        with patch.object(self.hand._motor_client, 'write_desired_pos', wraps=self.hand._motor_client.write_desired_pos) as mock_write:
-            self.hand.jitter(amplitude=5.0, duration=0.2)
-            self.assertGreater(len(mock_write.call_args_list), 0)
-            for call_args in mock_write.call_args_list:
-                self.assertNotIn(self.wrist_motor_id, call_args[0][0])
-
-    def test_wrist_excluded_even_with_many_motors(self):
-        non_wrist_ids = [mid for mid in self.hand.motor_ids if mid != self.wrist_motor_id]
-        with patch.object(self.hand._motor_client, 'write_desired_pos', wraps=self.hand._motor_client.write_desired_pos) as mock_write:
-            self.hand.jitter(amplitude=5.0, duration=0.2)
-            self.assertGreater(len(mock_write.call_args_list), 0)
-            commanded_ids = set(mock_write.call_args_list[0][0][0])
-            self.assertEqual(commanded_ids, set(non_wrist_ids))
-
-    # ── Wrist included with flag ──
-
-    def test_include_wrist_flag(self):
-        with patch.object(self.hand._motor_client, 'write_desired_pos', wraps=self.hand._motor_client.write_desired_pos) as mock_write:
-            self.hand.jitter(amplitude=5.0, duration=0.2, include_wrist=True)
-            self.assertGreater(len(mock_write.call_args_list), 0)
-            commanded_ids = set(mock_write.call_args_list[0][0][0])
-            self.assertIn(self.wrist_motor_id, commanded_ids)
-
-    # ── Works before calibration (motor level) ──
-
-    def test_works_without_calibration(self):
-        uncalibrated = MockOrcaHand()
-        uncalibrated.connect()
-        try:
-            uncalibrated.jitter(amplitude=5.0, duration=0.2)
-        finally:
-            uncalibrated.disconnect()
-
-    # ── Returns to starting position ──
-
-    def test_returns_to_start_position(self):
-        positions_before = self.hand.get_motor_pos()
-        self.hand.jitter(amplitude=5.0, duration=0.5)
-        positions_after = self.hand.get_motor_pos()
-        np.testing.assert_allclose(positions_after, positions_before, atol=1e-6)
-
-    # ── Non-blocking + stop ──
-
-    def test_non_blocking_runs_in_background(self):
-        self.hand.jitter(amplitude=5.0, duration=5.0, blocking=False)
-        time.sleep(0.2)
-        self.assertTrue(self.hand._task_thread.is_alive())
-        self.hand.stop_task()
-        time.sleep(0.2)
-        self.assertFalse(self.hand._task_thread.is_alive())
-
-    def test_early_stop_returns_to_start(self):
-        positions_before = self.hand.get_motor_pos()
-        self.hand.jitter(amplitude=5.0, duration=10.0, blocking=False)
-        time.sleep(0.3)
-        self.hand.stop_task()
-        time.sleep(0.2)
-        positions_after = self.hand.get_motor_pos()
-        np.testing.assert_allclose(positions_after, positions_before, atol=1e-6)
-
-    # ── Concurrent task rejection ──
-
-    def test_second_jitter_rejected(self):
-        self.hand.jitter(amplitude=5.0, duration=5.0, blocking=False)
-        time.sleep(0.1)
-        self.hand.jitter(amplitude=5.0, duration=5.0, blocking=False)
-        self.assertTrue(self.hand._task_thread.is_alive())
-        self.assertEqual(self.hand._current_task, '_jitter')
-        self.hand.stop_task()
-        time.sleep(0.2)
-        self.assertFalse(self.hand._task_thread.is_alive())
+@pytest.fixture
+def mock_hand():
+    hand = MockOrcaHand()
+    success, msg = hand.connect()
+    assert success, f"Failed to connect mock hand: {msg}"
+    yield hand
+    hand.stop_task()
+    time.sleep(0.1)
+    hand.disconnect()
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture
+def wrist_motor_id(mock_hand):
+    return mock_hand.joint_to_motor_map.get("wrist")
+
+
+def test_amplitude_exceeds_max_raises_error(mock_hand):
+    with pytest.raises(ValueError):
+        mock_hand.jitter(amplitude=15.0, duration=0.1)
+
+
+def test_amplitude_at_max_allowed(mock_hand):
+    mock_hand.jitter(amplitude=10.0, duration=0.1)
+
+
+def test_amplitude_below_max(mock_hand):
+    mock_hand.jitter(amplitude=3.0, duration=0.1)
+
+
+def test_default_frequency_is_fast(mock_hand):
+    sig = inspect.signature(mock_hand.jitter)
+    default_freq = sig.parameters['frequency'].default
+    assert default_freq >= 10.0
+
+
+def test_duration_respected(mock_hand):
+    start = time.time()
+    mock_hand.jitter(duration=1.0, amplitude=2.0)
+    elapsed = time.time() - start
+    assert elapsed == pytest.approx(1.0, abs=0.3)
+
+
+def test_short_duration(mock_hand):
+    start = time.time()
+    mock_hand.jitter(duration=0.3, amplitude=2.0)
+    elapsed = time.time() - start
+    assert elapsed < 1.0
+
+
+def test_custom_motor_ids(mock_hand):
+    target_id = mock_hand.motor_ids[0]
+    with patch.object(mock_hand._motor_client, 'write_desired_pos', wraps=mock_hand._motor_client.write_desired_pos) as mock_write:
+        mock_hand.jitter(motor_ids=[target_id], amplitude=5.0, duration=0.2)
+        assert len(mock_write.call_args_list) > 0
+        for call_args in mock_write.call_args_list:
+            assert call_args[0][0] == [target_id]
+
+
+def test_default_excludes_wrist(mock_hand, wrist_motor_id):
+    assert wrist_motor_id is not None, "Config must have a wrist motor for this test"
+    with patch.object(mock_hand._motor_client, 'write_desired_pos', wraps=mock_hand._motor_client.write_desired_pos) as mock_write:
+        mock_hand.jitter(amplitude=5.0, duration=0.2)
+        assert len(mock_write.call_args_list) > 0
+        for call_args in mock_write.call_args_list:
+            assert wrist_motor_id not in call_args[0][0]
+
+
+def test_wrist_excluded_even_with_many_motors(mock_hand, wrist_motor_id):
+    non_wrist_ids = [mid for mid in mock_hand.motor_ids if mid != wrist_motor_id]
+    with patch.object(mock_hand._motor_client, 'write_desired_pos', wraps=mock_hand._motor_client.write_desired_pos) as mock_write:
+        mock_hand.jitter(amplitude=5.0, duration=0.2)
+        assert len(mock_write.call_args_list) > 0
+        commanded_ids = set(mock_write.call_args_list[0][0][0])
+        assert commanded_ids == set(non_wrist_ids)
+
+
+def test_include_wrist_flag(mock_hand, wrist_motor_id):
+    with patch.object(mock_hand._motor_client, 'write_desired_pos', wraps=mock_hand._motor_client.write_desired_pos) as mock_write:
+        mock_hand.jitter(amplitude=5.0, duration=0.2, include_wrist=True)
+        assert len(mock_write.call_args_list) > 0
+        commanded_ids = set(mock_write.call_args_list[0][0][0])
+        assert wrist_motor_id in commanded_ids
+
+
+def test_works_without_calibration():
+    uncalibrated = MockOrcaHand()
+    uncalibrated.connect()
+    try:
+        uncalibrated.jitter(amplitude=5.0, duration=0.2)
+    finally:
+        uncalibrated.disconnect()
+
+
+def test_returns_to_start_position(mock_hand):
+    positions_before = mock_hand.get_motor_pos()
+    mock_hand.jitter(amplitude=5.0, duration=0.5)
+    positions_after = mock_hand.get_motor_pos()
+    np.testing.assert_allclose(positions_after, positions_before, atol=1e-6)
+
+
+def test_non_blocking_runs_in_background(mock_hand):
+    mock_hand.jitter(amplitude=5.0, duration=5.0, blocking=False)
+    time.sleep(0.2)
+    assert mock_hand._task_thread.is_alive()
+    mock_hand.stop_task()
+    time.sleep(0.2)
+    assert not mock_hand._task_thread.is_alive()
+
+
+def test_early_stop_returns_to_start(mock_hand):
+    positions_before = mock_hand.get_motor_pos()
+    mock_hand.jitter(amplitude=5.0, duration=10.0, blocking=False)
+    time.sleep(0.3)
+    mock_hand.stop_task()
+    time.sleep(0.2)
+    positions_after = mock_hand.get_motor_pos()
+    np.testing.assert_allclose(positions_after, positions_before, atol=1e-6)
+
+
+def test_second_jitter_rejected(mock_hand):
+    mock_hand.jitter(amplitude=5.0, duration=5.0, blocking=False)
+    time.sleep(0.1)
+    mock_hand.jitter(amplitude=5.0, duration=5.0, blocking=False)
+    assert mock_hand._task_thread.is_alive()
+    assert mock_hand._current_task == '_jitter'
+    mock_hand.stop_task()
+    time.sleep(0.2)
+    assert not mock_hand._task_thread.is_alive()

--- a/tests/test_tension.py
+++ b/tests/test_tension.py
@@ -1,59 +1,51 @@
-import unittest
 import time
+
+import pytest
 from orca_core import MockOrcaHand
 
-class TestOrcaHandTension(unittest.TestCase):
 
-    def setUp(self):
-        """Set up a mock hand and connect."""
-        self.hand = MockOrcaHand()
-        success, msg = self.hand.connect()
-        self.assertTrue(success, f"Failed to connect mock hand: {msg}")
+@pytest.fixture
+def mock_hand():
+    hand = MockOrcaHand()
+    success, msg = hand.connect()
+    assert success, f"Failed to connect mock hand: {msg}"
+    yield hand
+    hand.stop_task()
+    time.sleep(0.1)
+    hand.disconnect()
 
-    def tearDown(self):
-        """Disconnect after each test."""
-        self.hand.stop_task()  
-        time.sleep(0.1)  
-        self.hand.disconnect()
 
-    def test_tension_move_motors_false(self):
-        """Test tension function with move_motors=False."""
-        self.hand.tension(move_motors=False, blocking=False)
-        self.assertTrue(self.hand._task_thread.is_alive())
-        self.hand.stop_task()
-        time.sleep(0.1)
-        self.assertFalse(self.hand._task_thread.is_alive())
+def test_tension_move_motors_false(mock_hand):
+    mock_hand.tension(move_motors=False, blocking=False)
+    assert mock_hand._task_thread.is_alive()
+    mock_hand.stop_task()
+    time.sleep(0.1)
+    assert not mock_hand._task_thread.is_alive()
 
-    def test_tension_move_motors_true(self):
-        """Test tension function with move_motors=True."""
-        self.hand.tension(move_motors=True, blocking=False)
-        time.sleep(1)
-        self.assertTrue(self.hand._task_thread.is_alive())
-        self.hand.stop_task()
-        time.sleep(0.1)
-        self.assertFalse(self.hand._task_thread.is_alive())
 
-    def test_tension_interrupt_after_3_seconds(self):
-        """Start tension, wait 3 seconds, then interrupt."""
-        self.hand.tension(move_motors=True, blocking=False)
-        time.sleep(3)
-        self.assertTrue(self.hand._task_thread.is_alive(), "Tension task should still be running")
-        self.hand.stop_task()
-        time.sleep(0.1)
-        self.assertFalse(self.hand._task_thread.is_alive(), "Tension task should have stopped")
+def test_tension_move_motors_true(mock_hand):
+    mock_hand.tension(move_motors=True, blocking=False)
+    time.sleep(1)
+    assert mock_hand._task_thread.is_alive()
+    mock_hand.stop_task()
+    time.sleep(0.1)
+    assert not mock_hand._task_thread.is_alive()
 
-    def test_second_tension_is_rejected(self):
-        """Ensure that starting a second tension is rejected while one is running."""
-        self.hand.tension(move_motors=True, blocking=False)
 
-        self.hand.tension(move_motors=True, blocking=False)
+def test_tension_interrupt_after_3_seconds(mock_hand):
+    mock_hand.tension(move_motors=True, blocking=False)
+    time.sleep(3)
+    assert mock_hand._task_thread.is_alive(), "Tension task should still be running"
+    mock_hand.stop_task()
+    time.sleep(0.1)
+    assert not mock_hand._task_thread.is_alive(), "Tension task should have stopped"
 
-        self.assertTrue(self.hand._task_thread.is_alive())
-        self.assertEqual(self.hand._current_task, '_tension')
 
-        self.hand.stop_task()
-        time.sleep(0.1)
-        self.assertFalse(self.hand._task_thread.is_alive())
-
-if __name__ == '__main__':
-    unittest.main()
+def test_second_tension_is_rejected(mock_hand):
+    mock_hand.tension(move_motors=True, blocking=False)
+    mock_hand.tension(move_motors=True, blocking=False)
+    assert mock_hand._task_thread.is_alive()
+    assert mock_hand._current_task == '_tension'
+    mock_hand.stop_task()
+    time.sleep(0.1)
+    assert not mock_hand._task_thread.is_alive()

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,59 +1,61 @@
-import unittest
 import os
+
 import numpy as np
+import pytest
 import yaml
 from orca_core.utils import update_yaml, read_yaml
 
-class TestYamlFunctions(unittest.TestCase):
 
-    def setUp(self):
-        self.test_file = 'test.yaml'
-        self.initial_data = {
-            'key1': 'value1',
-            'key2': [1, 2, 3],
-            'key3': {'subkey1': 'subvalue1'}
-        }
-        with open(self.test_file, 'w') as file:
-            yaml.dump(self.initial_data, file, default_flow_style=False, sort_keys=False)
+@pytest.fixture
+def yaml_file(tmp_path):
+    test_file = tmp_path / "test.yaml"
+    initial_data = {
+        'key1': 'value1',
+        'key2': [1, 2, 3],
+        'key3': {'subkey1': 'subvalue1'},
+    }
+    with open(test_file, 'w') as f:
+        yaml.dump(initial_data, f, default_flow_style=False, sort_keys=False)
+    return str(test_file), initial_data
 
-    def tearDown(self):
-        if os.path.exists(self.test_file):
-            os.remove(self.test_file)
 
-    def test_update_yaml_with_string(self):
-        update_yaml(self.test_file, 'key1', 'new_value1')
-        data = read_yaml(self.test_file)
-        self.assertEqual(data['key1'], 'new_value1')
+def test_update_yaml_with_string(yaml_file):
+    test_file, _ = yaml_file
+    update_yaml(test_file, 'key1', 'new_value1')
+    data = read_yaml(test_file)
+    assert data['key1'] == 'new_value1'
 
-    def test_update_yaml_with_list(self):
-        update_yaml(self.test_file, 'key2', [4, 5, 6])
-        data = read_yaml(self.test_file)
-        self.assertEqual(data['key2'], [4, 5, 6])
 
-    def test_update_yaml_with_dict(self):
-        update_yaml(self.test_file, 'key3', {'subkey2': 'subvalue2'})
-        data = read_yaml(self.test_file)
-        self.assertEqual(data['key3'], {'subkey2': 'subvalue2'})
+def test_update_yaml_with_list(yaml_file):
+    test_file, _ = yaml_file
+    update_yaml(test_file, 'key2', [4, 5, 6])
+    data = read_yaml(test_file)
+    assert data['key2'] == [4, 5, 6]
 
-    def test_update_yaml_with_numpy_array(self):
-        array = np.array([7, 8, 9])
-        update_yaml(self.test_file, 'key4', array)
-        data = read_yaml(self.test_file)
-        self.assertEqual(data['key4'], [7, 8, 9])
 
-    def test_read_yaml(self):
-        data = read_yaml(self.test_file)
-        self.assertEqual(data, self.initial_data)
+def test_update_yaml_with_dict(yaml_file):
+    test_file, _ = yaml_file
+    update_yaml(test_file, 'key3', {'subkey2': 'subvalue2'})
+    data = read_yaml(test_file)
+    assert data['key3'] == {'subkey2': 'subvalue2'}
 
-    def test_update_yaml_creates_file(self):
-        new_file = 'new_test.yaml'
-        try:
-            update_yaml(new_file, 'key1', 'value1')
-            data = read_yaml(new_file)
-            self.assertEqual(data['key1'], 'value1')
-        finally:
-            if os.path.exists(new_file):
-                os.remove(new_file)
 
-if __name__ == '__main__':
-    unittest.main()
+def test_update_yaml_with_numpy_array(yaml_file):
+    test_file, _ = yaml_file
+    array = np.array([7, 8, 9])
+    update_yaml(test_file, 'key4', array)
+    data = read_yaml(test_file)
+    assert data['key4'] == [7, 8, 9]
+
+
+def test_read_yaml(yaml_file):
+    test_file, initial_data = yaml_file
+    data = read_yaml(test_file)
+    assert data == initial_data
+
+
+def test_update_yaml_creates_file(tmp_path):
+    new_file = str(tmp_path / "new_test.yaml")
+    update_yaml(new_file, 'key1', 'value1')
+    data = read_yaml(new_file)
+    assert data['key1'] == 'value1'


### PR DESCRIPTION
## Summary
- Refactored all 6 unittest-based test files to use idiomatic pytest patterns
- Replaced `unittest.TestCase` classes with plain test functions
- Replaced `setUp`/`tearDown` with pytest fixtures (`tmp_path`, `yield`-based cleanup)
- Replaced `self.assert*` methods with plain `assert` + `pytest.approx` / `pytest.raises`
- Removed boilerplate (`if __name__` blocks, `import unittest`)
- All 35 tests pass unchanged in behavior

## Test plan
- [x] `uv run pytest tests/ -v` — all 35 tests pass
- [ ] Review each file to confirm test logic is preserved