### PR TITLE
Rename calib_* to calibration_* in V1 configs and docs

### DIFF
--- a/docs/pages/getting-started-docs/setting-up-config.md
+++ b/docs/pages/getting-started-docs/setting-up-config.md
@@ -120,11 +120,11 @@ You can adjust this section if you want the hand to return to a different defaul
 ### 6. Calibration Parameters
 
 ```yaml
-calib_current: 350
-calib_step_size: 0.1
-calib_step_period: 0.001
-calib_num_stable: 10
-calib_threshold: 0.01
+calibration_current: 350
+calibration_step_size: 0.1
+calibration_step_period: 0.001
+calibration_num_stable: 10
+calibration_threshold: 0.01
 ```
 
 **What should be changed?**
@@ -136,7 +136,7 @@ These parameters should generally not be changed unless you have experience tuni
 ### 7. Calibration Sequence
 
 ```yaml
-calib_sequence:
+calibration_sequence:
     - step: 1
       joints:
         thumb_mcp: flex

--- a/orca_core/hardware_hand.py
+++ b/orca_core/hardware_hand.py
@@ -477,7 +477,7 @@ class OrcaHand(BaseHand):
         """Run the joint calibration routine.
 
         Drives each joint to its mechanical limits in the sequence defined by
-        ``calib_sequence`` in ``config.yaml``, records the motor positions at
+        ``calibration_sequence`` in ``config.yaml``, records the motor positions at
         each limit, and persists the resulting motor limits and joint-to-motor
         ratios to ``calibration.yaml``.
 
@@ -519,7 +519,7 @@ class OrcaHand(BaseHand):
     def _calibrate(self, force_wrist: bool = False) -> CalibrationResult | None:
         """Execute the calibration routine and return a :class:`~orca_core.CalibrationResult`.
 
-        Drives each joint through its mechanical limits following ``calib_sequence``
+        Drives each joint through its mechanical limits following ``calibration_sequence``
         from ``config.yaml``, records motor positions at each limit, and persists
         the resulting motor limits and joint-to-motor ratios to ``calibration.yaml``
         after every step. Returns ``None`` on early exit (stop event triggered).

--- a/orca_core/models/v1/orcahand_left/config.yaml
+++ b/orca_core/models/v1/orcahand_left/config.yaml
@@ -128,12 +128,12 @@ neutral_position:
   pinky_mcp: 1
   pinky_pip: 0
   wrist: 0
-calib_current: 350
-calib_step_size: 0.1
-calib_step_period: 0.001
-calib_num_stable: 10
-calib_threshold: 0.01
-calib_sequence:
+calibration_current: 350
+calibration_step_size: 0.1
+calibration_step_period: 0.001
+calibration_num_stable: 10
+calibration_threshold: 0.01
+calibration_sequence:
 - step: 1
   joints:
     thumb_mcp: flex

--- a/orca_core/models/v1/orcahand_right/config.yaml
+++ b/orca_core/models/v1/orcahand_right/config.yaml
@@ -70,13 +70,13 @@ neutral_position:
   pinky_pip: 0
   wrist: 0
 
-calib_current: 350
-calib_step_size: 0.1
-calib_step_period: 0.001
-calib_num_stable: 10  # should be period * num_stable > 1
-calib_threshold: 0.01
+calibration_current: 350
+calibration_step_size: 0.1
+calibration_step_period: 0.001
+calibration_num_stable: 10  # should be period * num_stable > 1
+calibration_threshold: 0.01
 
-calib_sequence:
+calibration_sequence:
   - step: 1
     joints:
       thumb_mcp: flex
@@ -168,7 +168,7 @@ calib_sequence:
     joints:
       wrist: extend
 
-# calib_sequence:
+# calibration_sequence:
 #   - step: 1
 #     joints:
 #       pinky_pip: flex


### PR DESCRIPTION
V1 configs were using the old calib_* naming but hand_config.py only parses calibration_*, so V1 hands silently fell back to defaults and skipped finger calibration entirely. Rename all six keys in both V1 configs, update the setting-up-config doc, and fix two stale references in hardware_hand.py docstrings.