### PR TITLE
Improve Feetech motor client: sync motion, direction handling, motion…

### DIFF
--- a/orca_core/hardware/feetech_client.py
+++ b/orca_core/hardware/feetech_client.py
@@ -27,6 +27,7 @@ from .feetech import (
     SMS_STS_PRESENT_SPEED_L,
     SMS_STS_PRESENT_CURRENT_L,
     SMS_STS_PRESENT_TEMPERATURE,
+    SMS_STS_MOVING,
     SMS_STS_ACC,
     SMS_STS_GOAL_POSITION_L,
     SMS_STS_GOAL_TIME_L,
@@ -41,6 +42,12 @@ DEFAULT_CUR_SCALE = 6.5  # mA per unit
 # Position limits for STS servo mode (0-4095, one full rotation)
 POS_MIN = 0
 POS_MAX = 4095
+
+# Feetech servos rotate in the opposite direction from Dynamixel for the same
+# raw command. We invert here so OrcaHand sees a single, motor-type-agnostic
+# convention; per-joint sign tuning (joint_to_motor_map) can then be shared
+# across motor types.
+POSITION_DIRECTION = -1
 
 
 def feetech_cleanup_handler():
@@ -242,7 +249,15 @@ class FeetechClient(MotorClient):
         self.set_torque_enabled(motor_ids, True)
 
     def read_pos_vel_cur(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """Reads position, velocity, and current for all motors."""
+        """Reads position, velocity, and current for all motors.
+
+        Tries sync read first (one packet for all motors); falls back to
+        per-motor reads only if the sync transaction fails.
+        """
+        return self.read_pos_vel_cur_sync()
+
+    def _read_pos_vel_cur_individual(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Per-motor fallback used only when sync read fails."""
         self._check_connected()
 
         positions = np.zeros(len(self.motor_ids), dtype=np.float32)
@@ -257,7 +272,7 @@ class FeetechClient(MotorClient):
             if result == COMM_SUCCESS and error == 0:
                 pos_signed = self.packet_handler.scs_tohost(pos_raw, 15)
                 pos_normalized = self._normalize_position(pos_signed)
-                positions[i] = pos_normalized * self.pos_scale
+                positions[i] = pos_normalized * self.pos_scale * POSITION_DIRECTION
             else:
                 logging.warning(
                     'Failed to read position for motor %d: result=%d, error=%d',
@@ -270,7 +285,7 @@ class FeetechClient(MotorClient):
             )
             if result == COMM_SUCCESS and error == 0:
                 vel_signed = self.packet_handler.scs_tohost(vel_raw, 15)
-                velocities[i] = vel_signed * self.vel_scale
+                velocities[i] = vel_signed * self.vel_scale * POSITION_DIRECTION
             else:
                 logging.warning(
                     'Failed to read velocity for motor %d: result=%d, error=%d',
@@ -293,11 +308,31 @@ class FeetechClient(MotorClient):
         return positions, velocities, currents
 
     def read_temperature(self) -> np.ndarray:
-        """Reads the temperature for all motors."""
+        """Reads the temperature for all motors via a single sync-read packet."""
         self._check_connected()
 
         temperatures = np.zeros(len(self.motor_ids), dtype=np.float32)
 
+        sync_read = GroupSyncRead(self.packet_handler, SMS_STS_PRESENT_TEMPERATURE, 1)
+        for motor_id in self.motor_ids:
+            sync_read.addParam(motor_id)
+
+        if sync_read.txRxPacket() != COMM_SUCCESS:
+            logging.warning('Sync temp read failed, falling back to individual reads')
+            return self._read_temperature_individual()
+
+        for i, motor_id in enumerate(self.motor_ids):
+            available, _ = sync_read.isAvailable(motor_id, SMS_STS_PRESENT_TEMPERATURE, 1)
+            if available:
+                temperatures[i] = float(sync_read.getData(motor_id, SMS_STS_PRESENT_TEMPERATURE, 1))
+            else:
+                logging.warning('Motor %d not available in sync temp read', motor_id)
+
+        return temperatures
+
+    def _read_temperature_individual(self) -> np.ndarray:
+        """Per-motor fallback used only when sync temp read fails."""
+        temperatures = np.zeros(len(self.motor_ids), dtype=np.float32)
         for i, motor_id in enumerate(self.motor_ids):
             temp, result, error = self.packet_handler.read1ByteTxRx(
                 motor_id, SMS_STS_PRESENT_TEMPERATURE
@@ -312,6 +347,52 @@ class FeetechClient(MotorClient):
 
         return temperatures
 
+    def wait_for_motion_complete(
+        self,
+        timeout: float = 5.0,
+        poll_interval: float = 0.02,
+    ) -> bool:
+        """Block until every motor reports it has stopped, or timeout elapses.
+
+        Reads each motor's MOVING flag (register 66) via sync read; the bit
+        is 1 while the servo is travelling toward its goal position and 0
+        once it has settled.
+
+        Args:
+            timeout: Max seconds to wait before giving up.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            True if all motors stopped within the timeout, False otherwise.
+        """
+        self._check_connected()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            sync_read = GroupSyncRead(self.packet_handler, SMS_STS_MOVING, 1)
+            for motor_id in self.motor_ids:
+                sync_read.addParam(motor_id)
+
+            if sync_read.txRxPacket() != COMM_SUCCESS:
+                time.sleep(poll_interval)
+                continue
+
+            all_stopped = True
+            for motor_id in self.motor_ids:
+                available, _ = sync_read.isAvailable(motor_id, SMS_STS_MOVING, 1)
+                if not available:
+                    all_stopped = False
+                    break
+                if sync_read.getData(motor_id, SMS_STS_MOVING, 1) != 0:
+                    all_stopped = False
+                    break
+
+            if all_stopped:
+                return True
+            time.sleep(poll_interval)
+
+        logging.warning('wait_for_motion_complete: timed out after %.1fs', timeout)
+        return False
+
     def write_desired_pos(
         self,
         motor_ids: Sequence[int],
@@ -321,42 +402,16 @@ class FeetechClient(MotorClient):
     ) -> None:
         """Writes desired positions to the motors.
 
+        Routes through ``write_positions_sync`` so all motors receive their
+        targets in a single broadcast packet (one round-trip instead of N).
+
         Args:
             motor_ids: Motor IDs to write to.
             positions: Target positions in radians.
             speed: Movement speed (0.732 RPM per unit). Default ~60 = 44 RPM.
             torque: Torque limit (0-1000). Default 500. Required for motion.
         """
-        self._check_connected()
-
-        if len(motor_ids) != len(positions):
-            raise ValueError('motor_ids and positions must have the same length')
-
-        speed = speed if speed is not None else self._default_speed
-        torque = torque if torque is not None else self._default_torque
-
-        for motor_id, pos_rad in zip(motor_ids, positions):
-            # Convert radians to raw position and clamp to valid range
-            pos_raw = int(pos_rad / self.pos_scale)
-            pos_raw = self._clamp_position(pos_raw)
-
-            logging.debug(
-                'WritePosEx: motor=%d, pos=%d, speed=%d, acc=%d, torque=%d',
-                motor_id, pos_raw, speed, self._default_acc, torque
-            )
-
-            result, error = self.packet_handler.WritePosEx(
-                motor_id,
-                pos_raw,
-                speed,
-                self._default_acc,
-                torque,
-            )
-            if result != COMM_SUCCESS or error != 0:
-                logging.error(
-                    'Failed to write position to motor %d: result=%d, error=%d',
-                    motor_id, result, error
-                )
+        self.write_positions_sync(motor_ids, positions, speed=speed, torque=torque)
 
     def write_desired_current(
         self,
@@ -428,6 +483,13 @@ class FeetechClient(MotorClient):
         """
         self._check_connected()
 
+        # OrcaHand's "upper" means the FLEX-side limit in its read frame. With
+        # POSITION_DIRECTION = -1 that maps to LOW raw (since raw → -raw·scale),
+        # so we flip which raw end gets the buffer; otherwise the next-direction
+        # motion saturates against the encoder boundary after only ~44°.
+        if POSITION_DIRECTION < 0:
+            upper = not upper
+
         # Buffer of 500 (~44°) ensures room for tendon loosening over time
         target_position = 3595 if upper else 500
 
@@ -472,12 +534,16 @@ class FeetechClient(MotorClient):
     ) -> None:
         """Writes positions to multiple motors using sync write.
 
-        More efficient than individual writes for multiple motors.
+        When ``speed`` is None (the default), per-motor speeds are scaled
+        proportional to each motor's distance-to-target, so motors with longer
+        trips run faster and all motors finish in sync. Pass an explicit
+        ``speed`` to disable the scaling and use a uniform speed.
 
         Args:
             motor_ids: Motor IDs to write to.
             positions: Target positions in radians.
-            speed: Movement speed (0.732 RPM per unit). Default ~60 = 44 RPM.
+            speed: Optional uniform speed (0.732 RPM/unit). If None, scales
+                per motor for synchronized arrival.
             acc: Acceleration (0-254). Default 50.
             torque: Torque limit (0-1000). Default 500.
         """
@@ -486,23 +552,28 @@ class FeetechClient(MotorClient):
         if len(motor_ids) != len(positions):
             raise ValueError('motor_ids and positions must have the same length')
 
-        speed = speed if speed is not None else self._default_speed
         acc = acc if acc is not None else self._default_acc
         torque = torque if torque is not None else self._default_torque
+
+        positions_arr = np.asarray(positions, dtype=float)
+        if speed is None:
+            speeds = self._compute_sync_speeds(motor_ids, positions_arr)
+        else:
+            speeds = np.full(len(motor_ids), int(speed), dtype=int)
 
         # Clear any existing sync write params
         self.packet_handler.groupSyncWrite.clearParam()
 
-        for motor_id, pos_rad in zip(motor_ids, positions):
-            pos_raw = int(pos_rad / self.pos_scale)
+        for motor_id, pos_rad, mspeed in zip(motor_ids, positions_arr, speeds):
+            pos_raw = int(pos_rad * POSITION_DIRECTION / self.pos_scale)
             pos_raw = self._clamp_position(pos_raw)
 
             logging.debug(
                 'SyncWritePosEx: motor=%d, pos=%d, speed=%d, acc=%d, torque=%d',
-                motor_id, pos_raw, speed, acc, torque
+                motor_id, pos_raw, int(mspeed), acc, torque
             )
 
-            self.packet_handler.SyncWritePosEx(motor_id, pos_raw, speed, acc, torque)
+            self.packet_handler.SyncWritePosEx(motor_id, pos_raw, int(mspeed), acc, torque)
 
         # Send the sync write packet
         result = self.packet_handler.groupSyncWrite.txPacket()
@@ -511,6 +582,34 @@ class FeetechClient(MotorClient):
 
         # Clear params for next use
         self.packet_handler.groupSyncWrite.clearParam()
+
+    def _compute_sync_speeds(
+        self,
+        motor_ids: Sequence[int],
+        target_positions: np.ndarray,
+    ) -> np.ndarray:
+        """Per-motor speeds (raw units) scaled so motors arrive together.
+
+        Reads current positions once, scales each motor's speed by its share
+        of the largest absolute delta. The motor with the largest move runs at
+        ``self._default_speed``; smaller moves run proportionally slower.
+        """
+        current = self.read_pos_vel_cur()[0]
+        motor_to_idx = {mid: i for i, mid in enumerate(self.motor_ids)}
+        deltas = np.array([
+            target_positions[i] - current[motor_to_idx[motor_ids[i]]]
+            for i in range(len(motor_ids))
+        ])
+        abs_deltas = np.abs(deltas)
+        max_delta = abs_deltas.max() if abs_deltas.size else 0.0
+        if max_delta < 1e-6:
+            return np.full(len(motor_ids), self._default_speed, dtype=int)
+        ratios = abs_deltas / max_delta
+        # Clamp to [1, 1023]: 0 stalls the motor; 1023 is the protocol max.
+        return np.clip(
+            (ratios * self._default_speed).round().astype(int),
+            1, 1023,
+        )
 
     def read_pos_vel_cur_sync(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Reads position, velocity, and current for all motors using sync read.
@@ -533,7 +632,7 @@ class FeetechClient(MotorClient):
         result = sync_read.txRxPacket()
         if result != COMM_SUCCESS:
             logging.warning('Sync read failed, falling back to individual reads')
-            return self.read_pos_vel_cur()
+            return self._read_pos_vel_cur_individual()
 
         for i, motor_id in enumerate(self.motor_ids):
             available, error = sync_read.isAvailable(
@@ -543,11 +642,11 @@ class FeetechClient(MotorClient):
                 pos_raw = sync_read.getData(motor_id, SMS_STS_PRESENT_POSITION_L, 2)
                 pos_signed = self.packet_handler.scs_tohost(pos_raw, 15)
                 pos_normalized = self._normalize_position(pos_signed)
-                positions[i] = pos_normalized * self.pos_scale
+                positions[i] = pos_normalized * self.pos_scale * POSITION_DIRECTION
 
                 vel_raw = sync_read.getData(motor_id, SMS_STS_PRESENT_SPEED_L, 2)
                 vel_signed = self.packet_handler.scs_tohost(vel_raw, 15)
-                velocities[i] = vel_signed * self.vel_scale
+                velocities[i] = vel_signed * self.vel_scale * POSITION_DIRECTION
 
                 cur_raw = sync_read.getData(motor_id, SMS_STS_PRESENT_CURRENT_L, 2)
                 cur_signed = self.packet_handler.scs_tohost(cur_raw, 15)

--- a/orca_core/hardware/motor_client.py
+++ b/orca_core/hardware/motor_client.py
@@ -116,6 +116,23 @@ class MotorClient(ABC):
         """
         ...
 
+    def wait_for_motion_complete(self, timeout: float = 5.0) -> bool:
+        """Block until all motors finish their commanded motion.
+
+        Default implementation is a no-op for motor families that respond
+        fast enough that callers don't need to wait (e.g., Dynamixel, mock).
+        Slower buses like Feetech override this to poll a per-motor moving
+        flag.
+
+        Args:
+            timeout: Max seconds to wait.
+
+        Returns:
+            True if motion completed (or no waiting was needed), False on
+            timeout.
+        """
+        return True
+
     @property
     def requires_offset_calibration(self) -> bool:
         """Returns True if this motor type needs offset calibration during joint calibration."""

--- a/orca_core/hardware_hand.py
+++ b/orca_core/hardware_hand.py
@@ -366,6 +366,21 @@ class OrcaHand(BaseHand):
 
             return motor_current
 
+    def wait_for_motion(self, timeout: float = 5.0) -> bool:
+        """Block until all motors have settled at their commanded position.
+
+        No-op for motor types fast enough that callers don't need to wait
+        (e.g., Dynamixel). Feetech polls a per-motor moving flag.
+
+        Args:
+            timeout: Max seconds to wait.
+
+        Returns:
+            True if all motors stopped within the timeout, False otherwise.
+        """
+        with self._motor_lock:
+            return self._motor_client.wait_for_motion_complete(timeout=timeout)
+
     def get_motor_temp(self, as_dict: bool = False) -> Union[np.ndarray, dict]:
         """Read the present temperature of each motor.
 

--- a/orca_core/models/v2/orcahand_right_feetech/config.yaml
+++ b/orca_core/models/v2/orcahand_right_feetech/config.yaml
@@ -1,0 +1,203 @@
+port: /dev/cu.usbmodem1101
+version: 0.2.1
+baudrate: 1000000
+max_current: 300
+type: right
+motor_type: feetech
+control_mode: current_based_position
+motor_ids:
+- 1
+- 2
+- 3
+- 4
+- 5 
+- 6 
+- 7 
+- 8
+- 9
+- 10
+- 11
+- 12
+- 13
+- 14
+- 15
+- 16
+- 17
+joint_ids:
+- wrist
+- thumb_cmc
+- thumb_abd
+- thumb_mcp
+- thumb_dip
+- index_abd
+- index_mcp
+- index_pip
+- middle_abd
+- middle_mcp
+- middle_pip
+- ring_abd
+- ring_mcp
+- ring_pip
+- pinky_abd
+- pinky_mcp
+- pinky_pip
+joint_to_motor_map:
+  thumb_cmc: 17
+  thumb_abd: 14
+  thumb_mcp: 15
+  thumb_dip: 16
+  index_abd: 4
+  index_mcp: 3
+  index_pip: 2
+  middle_abd: 5
+  middle_mcp: 10
+  middle_pip: 9
+  ring_abd: 6
+  ring_mcp: -7
+  ring_pip: 8
+  pinky_abd: -13
+  pinky_mcp: 12
+  pinky_pip: -11
+  wrist: -1
+joint_roms:
+  wrist:
+  - -65
+  - 35
+  thumb_cmc:
+  - -42
+  - 47
+  thumb_abd:
+  - -18
+  - 55
+  thumb_mcp:
+  - -60
+  - 90
+  thumb_dip:
+  - -55
+  - 107
+  index_abd:
+  - -30
+  - 25
+  index_mcp:
+  - -60
+  - 100
+  index_pip:
+  - -15
+  - 107
+  middle_abd:
+  - -30
+  - 30
+  middle_mcp:
+  - -60
+  - 100
+  middle_pip:
+  - -20
+  - 107
+  ring_abd:
+  - -30
+  - 30
+  ring_mcp:
+  - -60
+  - 100
+  ring_pip:
+  - -15
+  - 107
+  pinky_abd:
+  - -30
+  - 30
+  pinky_mcp:
+  - -60
+  - 100
+  pinky_pip:
+  - -15
+  - 108
+neutral_position:
+  thumb_cmc: 0
+  thumb_abd: 50
+  thumb_mcp: 33
+  thumb_dip: 18
+  index_abd: -14
+  index_mcp: 2
+  index_pip: 6
+  middle_abd: -4
+  middle_mcp: 2
+  middle_pip: 4
+  ring_abd: 10
+  ring_mcp: -2
+  ring_pip: 8
+  pinky_abd: 22
+  pinky_mcp: -4
+  pinky_pip: -2
+  wrist: -20
+calibration_current: 300
+calibration_step_size: 0.15
+calibration_step_period: 0.0001
+calibration_num_stable: 10
+calibration_threshold: 0.01
+calibration_sequence:
+- step: 1
+  joints:
+    thumb_cmc: flex
+- step: 2
+  joints:
+    thumb_cmc: extend
+- step: 3
+  joints:
+    thumb_abd: flex
+- step: 4
+  joints:
+    thumb_abd: extend
+- step: 5
+  joints:
+    thumb_mcp: flex
+- step: 6
+  joints:
+    thumb_mcp: extend
+- step: 7
+  joints:
+    thumb_dip: flex
+- step: 8
+  joints:
+    thumb_dip: extend
+- step: 9
+  joints:
+    index_abd: flex
+    middle_abd: flex
+    ring_abd: flex
+    pinky_abd: flex
+- step: 10
+  joints:
+    index_abd: extend
+    middle_abd: extend
+    ring_abd: extend
+    pinky_abd: extend
+- step: 11
+  joints:
+    index_mcp: flex
+    middle_mcp: flex
+    ring_mcp: flex
+    pinky_mcp: flex
+- step: 12
+  joints:
+    index_mcp: extend
+    middle_mcp: extend
+    ring_mcp: extend
+    pinky_mcp: extend
+- step: 13
+  joints:
+    index_pip: flex
+    middle_pip: flex
+    ring_pip: flex
+    pinky_pip: flex
+- step: 14
+  joints:
+    index_pip: extend
+    middle_pip: extend
+    ring_pip: extend
+    pinky_pip: extend
+- step: 15
+  joints:
+    wrist: flex
+- step: 16
+  joints:
+    wrist: extend

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,169 @@
+"""Cycle the hand between OPEN and CLOSE poses while monitoring motor temperatures.
+
+Adapted from the fb/dev test.py for the current OrcaHand API.
+"""
+
+import argparse
+import time
+
+from common import add_hand_arguments, connect_hand, create_hand, shutdown_hand
+
+
+MAX_TEMP = 70  # °C — conservative across Dynamixel XC330/430 and Feetech STS3215
+TEMP_CHECK_INTERVAL = 2.0
+
+
+RST = "\033[0m"
+GREEN = "\033[92m"
+YELLOW = "\033[93m"
+RED = "\033[91m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+
+
+def temp_color(pct: float) -> str:
+    if pct >= 90:
+        return RED
+    if pct >= 70:
+        return YELLOW
+    return GREEN
+
+
+def print_temp_table(hand, temps: dict) -> None:
+    """Print a compact color-coded temperature table grouped by finger."""
+    motor_to_joint = hand.config.motor_to_joint_dict
+
+    fingers = ["thumb", "index", "middle", "ring", "pinky", "wrist"]
+    grouped = {f: [] for f in fingers}
+    for mid, t in temps.items():
+        joint = motor_to_joint.get(mid, f"motor_{mid}")
+        finger = joint.split("_")[0]
+        if finger in grouped:
+            grouped[finger].append((joint, mid, t))
+
+    print("\033[2J\033[H", end="")  # clear screen, cursor home
+
+    print(f"{BOLD}  ORCA Hand Temperature Monitor{RST}")
+    print(f"  {DIM}Max operating temp: {MAX_TEMP}°C{RST}\n")
+    print(f"  {BOLD}{'Joint':<14} {'Motor':>5} {'Temp':>6} {'%Max':>6}  {'':>10}{RST}")
+    print(f"  {'─' * 48}")
+
+    for finger in fingers:
+        for joint, mid, t in grouped[finger]:
+            pct = t / MAX_TEMP * 100
+            c = temp_color(pct)
+            bar_len = int(min(pct, 100) / 100 * 10)
+            bar = f"{c}{'█' * bar_len}{DIM}{'░' * (10 - bar_len)}{RST}"
+            print(f"  {joint:<14} {mid:>5} {c}{t:>4.0f}°C {pct:>5.0f}%{RST}  {bar}")
+
+    print(f"  {'─' * 48}")
+    if temps:
+        max_t = max(temps.values())
+        max_pct = max_t / MAX_TEMP * 100
+        c = temp_color(max_pct)
+        print(f"  {'Peak':<14} {'':>5} {c}{max_t:>4.0f}°C {max_pct:>5.0f}%{RST}\n")
+
+
+JOINT_OPEN = {
+    "index_abd": -30,
+    "middle_abd": 0,
+    "ring_abd": 10,
+    "pinky_abd": 25,
+    "thumb_abd": -20,
+    "index_mcp": -40,
+    "middle_mcp": -40,
+    "ring_mcp": -40,
+    "pinky_mcp": -40,
+    "thumb_mcp": 45,
+    "index_pip": -10,
+    "middle_pip": -10,
+    "ring_pip": -10,
+    "pinky_pip": -10,
+    "thumb_dip": 90,
+    "thumb_cmc": 40,
+    "wrist": -25,
+}
+
+JOINT_CLOSE = {
+    "index_abd": 15,
+    "middle_abd": 15,
+    "ring_abd": -15,
+    "pinky_abd": -15,
+    "thumb_abd": 55,
+    "index_mcp": 45,
+    "middle_mcp": 45,
+    "ring_mcp": 45,
+    "pinky_mcp": 45,
+    "thumb_mcp": -40,
+    "index_pip": 90,
+    "middle_pip": 90,
+    "ring_pip": 90,
+    "pinky_pip": 90,
+    "thumb_dip": -30,
+    "thumb_cmc": -50,
+    "wrist": 10,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Open/close cycle test with temperature monitoring."
+    )
+    add_hand_arguments(parser)
+    parser.add_argument(
+        "--num-steps", type=int, default=25,
+        help="Interpolation steps per move (default 25)."
+    )
+    parser.add_argument(
+        "--step-size", type=float, default=0.001,
+        help="Sleep between interpolation steps in seconds (default 0.001)."
+    )
+    parser.add_argument(
+        "--hold", type=float, default=0.0,
+        help="Extra seconds to hold each pose AFTER motion completes (default 0)."
+    )
+    parser.add_argument(
+        "--motion-timeout", type=float, default=5.0,
+        help="Max seconds to wait for a pose to be reached (default 5)."
+    )
+    args = parser.parse_args()
+
+    hand = create_hand(args.config_path, use_mock=args.mock)
+    try:
+        connect_hand(hand)
+        hand.enable_torque()
+
+        last_temp_check = 0.0
+        try:
+            while True:
+                now = time.monotonic()
+                if now - last_temp_check >= TEMP_CHECK_INTERVAL:
+                    last_temp_check = now
+                    temps = hand.get_motor_temp(as_dict=True)
+                    print_temp_table(hand, temps)
+                    if temps and max(temps.values()) >= MAX_TEMP:
+                        print(f"{RED}Motor temperature reached {MAX_TEMP}°C — aborting.{RST}")
+                        break
+
+                hand.set_joint_positions(
+                    JOINT_OPEN, num_steps=args.num_steps, step_size=args.step_size
+                )
+                hand.wait_for_motion(timeout=args.motion_timeout)
+                if args.hold:
+                    time.sleep(args.hold)
+
+                hand.set_joint_positions(
+                    JOINT_CLOSE, num_steps=args.num_steps, step_size=args.step_size
+                )
+                hand.wait_for_motion(timeout=args.motion_timeout)
+                if args.hold:
+                    time.sleep(args.hold)
+        except KeyboardInterrupt:
+            print("\nInterrupted.")
+        return 0
+    finally:
+        shutdown_hand(hand)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
…-complete polling

- Add POSITION_DIRECTION inversion at the driver boundary so Feetech matches the Dynamixel sign convention; joint_to_motor_map can be shared across motor types. calibrate_offset flips its buffer-end target accordingly so full joint ROMs fit in the single-rotation encoder range.

- Route write_desired_pos and read_pos_vel_cur through sync write / sync read (one broadcast packet for all motors instead of N round-trips). Same for read_temperature.

- Scale per-motor speed proportional to distance-to-target so motors with different travel distances finish their motion together.

- Add FeetechClient.wait_for_motion_complete (polls register 66 via sync read). Default no-op on MotorClient base so Dynamixel/mock are unaffected. Expose hand.wait_for_motion(timeout) on OrcaHand.

- Add scripts/test.py: open/close cycle with color-coded temperature monitor; uses wait_for_motion instead of a fixed sleep.

- Add orcahand_right_feetech model config.