### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [project]
 name = "orca_core"
-version = "0.2.1"
+version = "0.3.0"
 description = "Core Python Controller of the ORCA Hand. Handles all hardware interaction, logic and abstracts control. Provides API for basic functionality and info of the hand."
 authors = [
-    {name = "clemens-chr", email = "cchristoph@student.ethz.ch"}
+    {name = "clemens-chr", email = "cchristoph@student.ethz.ch"},
+    {name = "fabricenoelbourquin", email = "fabrice.bourquin@protonmail.ch"},
+    {name = "maximilianeberlein", email = "meberlein@ethz.ch"},
+    {name = "fracapuano", email = "capuano@robots.ox.ac.uk"},
 ]
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bumps `orca_core` from **0.2.1** → **0.3.0** in preparation for the v0.3.0 release.

Also expands the `authors` list in `pyproject.toml` to credit additional maintainers who contributed to this release cycle (hand refactor, v2 hands, tactile sensing).

## v0.3.0 highlights

- **Hand API refactor** — split `OrcaHand` into `BaseHand` / `HardwareHand`, typed joint positions, decoupled config from calibration state, mock motor client for hardware-free tests.
- **v2 hands** — versioned model resolution (`v1`/`v2`, left/right) and v2 calibration references.
- **Tactile sensing** — `TactileClient`, `OrcaHandTouch` subclass, `orcahand-touch` config under `v2/`, mock client and protocol tests.
- **Feetech driver support** — auto-detection of motor type and baudrate at connect time, persisted to `config.yaml`.
- **Tensioning & calibration** — motors move by default, stall detection, gradual torque release; per-joint/finger calibration CLI.
- **uv workflow** — migrated dependency management from Poetry to uv.


**Note**
After this PR is merged, a `v0.3.0` tag will be pushed against the merge commit. That tag triggers the existing `.github/workflows/release.yml` workflow, which publishes the package to PyPI. 

A matching GitHub release with full notes will be created at the same time.